### PR TITLE
Fix PHPDoc annotations

### DIFF
--- a/src/traits/ActiveFormAjaxSubmitTrait.php
+++ b/src/traits/ActiveFormAjaxSubmitTrait.php
@@ -11,6 +11,7 @@ namespace skeeks\cms\traits;
 use skeeks\cms\assets\ActiveFormAjaxSubmitAsset;
 use yii\helpers\Html;
 use yii\helpers\Inflector;
+use yii\web\JsExpression;
 
 /**
  *
@@ -35,7 +36,7 @@ JS
 trait ActiveFormAjaxSubmitTrait
 {
     /**
-     * @var null
+     * @var JsExpression|null
      */
     public $clientCallback = null;
 

--- a/src/widgets/AjaxSelectModel.php
+++ b/src/widgets/AjaxSelectModel.php
@@ -8,6 +8,7 @@
 
 namespace skeeks\cms\widgets;
 
+use skeeks\cms\base\ActiveRecord;
 use yii\base\InvalidConfigException;
 use yii\db\ActiveQuery;
 
@@ -30,7 +31,7 @@ use yii\db\ActiveQuery;
 class AjaxSelectModel extends AjaxSelect
 {
     /**
-     * @var null
+     * @var class-string<ActiveRecord>|null
      */
     public $modelClass = null;
 
@@ -50,7 +51,7 @@ class AjaxSelectModel extends AjaxSelect
     public $limit = 25;
 
     /**
-     * @var null
+     * @var callable|null
      */
     public $searchQuery = null;
 

--- a/src/widgets/user/UserOnlineWidget.php
+++ b/src/widgets/user/UserOnlineWidget.php
@@ -25,7 +25,7 @@ class UserOnlineWidget extends Widget
     public $user = null;
 
     /**
-     * @var null
+     * @var array|null
      */
     public $options = null;
 


### PR DESCRIPTION
Тестировал расширение [mspirkov/yii2-phpstan-rules](https://github.com/mspirkov/yii2-phpstan-rules) на вашем репозитории и нашёл ошибки в PHPDoc аннотациях. Решил поправить часть из них.

<img width="1193" height="147" alt="image_2026-07-22_13-42-27" src="https://github.com/user-attachments/assets/bf87d47c-9346-4ca9-90f2-6dab22758ad3" />
<img width="1263" height="177" alt="image_2026-07-22_13-48-41" src="https://github.com/user-attachments/assets/bf462c44-0ce3-4080-a2f6-9c0a91adbd58" />
<img width="1159" height="179" alt="image_2026-07-22_14-01-23" src="https://github.com/user-attachments/assets/0e5f9a60-7dbb-4bd0-b2dd-8819f1531dc0" />
